### PR TITLE
Updated blazeconfig with better dscale values for pose detection

### DIFF
--- a/blaze_common/blazeconfig.py
+++ b/blaze_common/blazeconfig.py
@@ -289,7 +289,7 @@ pose_detect_v0_10_model_config = {
     "kp1": 2,
     "kp2": 3,
     "theta0": 90 * np.pi / 180,
-    "dscale": 1.5,
+    "dscale": 2.5,
     "dy": 0.,
 }
 


### PR DESCRIPTION
Thanks to [pavloshargan](https://github.com/pavloshargan)'s work I was able to improve the dscale value for pose detection. I've improved the values so that it work with a variety of poses.

I discovered the following: 
- When dscale is too low, it crops the legs, e.g. dscale: 1.7:
![image](https://github.com/user-attachments/assets/da3a7f8b-5c77-46ef-997f-0965a9a29c02)
- When dscale is too high, it elongates the body region and places the feet too far from the body, e.g. dscale: 3
![image](https://github.com/user-attachments/assets/b48d998f-8c63-46f7-9da6-8adb2c805fac)
- when dy is over zero, it does not perform well on poses where the feet are above the head, e.g. dy: 0.5
![image](https://github.com/user-attachments/assets/c749b828-2c59-4626-8e54-422ddc5f0312)
